### PR TITLE
[CUDA12] use MaybeSetDevice in cuda device guard setDevice

### DIFF
--- a/c10/cuda/impl/CUDAGuardImpl.h
+++ b/c10/cuda/impl/CUDAGuardImpl.h
@@ -49,10 +49,17 @@ struct CUDAGuardImpl final : public c10::impl::DeviceGuardImplInterface {
     }
     return Device(DeviceType::CUDA, device);
   }
+#if CUDA_VERSION >= 12000
+  void setDevice(Device d) const override {
+    TORCH_INTERNAL_ASSERT(d.is_cuda());
+    C10_CUDA_CHECK(c10::cuda::MaybeSetDevice(d.index()));
+  }
+#else
   void setDevice(Device d) const override {
     TORCH_INTERNAL_ASSERT(d.is_cuda());
     C10_CUDA_CHECK(c10::cuda::SetDevice(d.index()));
   }
+#endif
   void uncheckedSetDevice(Device d) const noexcept override {
     C10_CUDA_CHECK_WARN(c10::cuda::MaybeSetDevice(d.index()));
   }


### PR DESCRIPTION
This PR leverages the MaybeSetDevice function in cuda device guard setDevice function to address the issue of unnecessary context memory allocation on cuda:0 when using other devices, such as XLA:GPU.